### PR TITLE
fix: 修复 loadMore 后，再点击页面还会触发 loadMore 的问题

### DIFF
--- a/src/scripts/PullRefresh.js
+++ b/src/scripts/PullRefresh.js
@@ -199,6 +199,7 @@ class PullRefresh {
   resetMore() {
     this.moreEl.style.visibility = 'hidden';
     this.loading = false;
+    this.enableMore = false;
     this.scroll.refresh();
 
     //打印日志，测试用


### PR DESCRIPTION
当页面上拉加载更多后，立刻点击页面，会再次触发 loadMore
原因是 touchend 时，enableMore 仍为 true